### PR TITLE
Compute composite variation weight from child products

### DIFF
--- a/src/features/products/hooks/use-composite-variations.ts
+++ b/src/features/products/hooks/use-composite-variations.ts
@@ -1,18 +1,33 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
-import { CompositeVariation, CreateCompositeVariationData, UpdateCompositeVariationData } from '@/lib/domain/entities/composite-variation';
-import { CreateCompositionItemData, UpdateCompositionItemData } from '@/lib/domain/entities/composition-item';
-import { ProductVariationItemRepository } from '@/lib/storage/repositories/product-variation-item-repository';
-import { CompositionItemRepository } from '@/lib/storage/repositories/composition-item-repository';
+import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  CompositeVariation,
+  CreateCompositeVariationData,
+  UpdateCompositeVariationData,
+} from "@/lib/domain/entities/composite-variation";
+import {
+  CreateCompositionItemData,
+  UpdateCompositionItemData,
+} from "@/lib/domain/entities/composition-item";
+import { ProductVariationItemRepository } from "@/lib/storage/repositories/product-variation-item-repository";
+import { CompositionItemRepository } from "@/lib/storage/repositories/composition-item-repository";
+import { ProductRepository } from "@/lib/storage/repositories/product-repository";
 
 export function useCompositeVariations(productSku: string) {
   const [variations, setVariations] = useState<CompositeVariation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const variationRepository = useMemo(() => new ProductVariationItemRepository(), []);
-  const compositionRepository = useMemo(() => new CompositionItemRepository(), []);
+  const variationRepository = useMemo(
+    () => new ProductVariationItemRepository(),
+    []
+  );
+  const compositionRepository = useMemo(
+    () => new CompositionItemRepository(),
+    []
+  );
+  const productRepository = useMemo(() => new ProductRepository(), []);
 
   // Load variations and their composition items
   const loadVariations = useCallback(async () => {
@@ -21,19 +36,28 @@ export function useCompositeVariations(productSku: string) {
       setError(null);
 
       // Get product variations
-      const productVariations = await variationRepository.findByProductSku(productSku);
-      
+      const productVariations =
+        await variationRepository.findByProductSku(productSku);
+
       // Build composite variations with composition items
       const compositeVariations: CompositeVariation[] = await Promise.all(
         productVariations.map(async (variation, index) => {
           const variationSku = `${productSku}#${variation.id}`;
-          const compositionItems = await compositionRepository.findByParent(variationSku);
-          
-          // Calculate total weight (simplified - in real app would lookup child product weights)
-          const totalWeight = compositionItems.reduce((sum, item) => {
-            // For now, assume each item has weight 1kg - in real app would lookup from product
-            return sum + (1 * item.quantity);
-          }, 0);
+          const compositionItems =
+            await compositionRepository.findByParent(variationSku);
+
+          // Calculate total weight using actual child product weights
+          const weights = await Promise.all(
+            compositionItems.map(async (item) => {
+              const product = await productRepository.findBySku(item.childSku);
+              return product?.weight ?? 0;
+            })
+          );
+
+          const totalWeight = compositionItems.reduce(
+            (sum, item, index) => sum + weights[index] * item.quantity,
+            0
+          );
 
           return {
             id: variation.id,
@@ -43,133 +67,177 @@ export function useCompositeVariations(productSku: string) {
             totalWeight,
             isActive: true,
             createdAt: variation.createdAt,
-            updatedAt: variation.updatedAt
+            updatedAt: variation.updatedAt,
           };
         })
       );
 
       setVariations(compositeVariations);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load variations');
+      setError(
+        err instanceof Error ? err.message : "Failed to load variations"
+      );
     } finally {
       setLoading(false);
     }
-  }, [productSku, variationRepository, compositionRepository]);
+  }, [
+    productSku,
+    variationRepository,
+    compositionRepository,
+    productRepository,
+  ]);
 
   // Create new variation
-  const createVariation = useCallback(async (data: CreateCompositeVariationData) => {
-    try {
-      setError(null);
+  const createVariation = useCallback(
+    async (data: CreateCompositeVariationData) => {
+      try {
+        setError(null);
 
-      // Create underlying product variation
-      const productVariation = await variationRepository.create({
-        productSku: data.productSku,
-        selections: {}, // Empty for composite variations
-        weightOverride: undefined
-      });
+        // Create underlying product variation
+        const productVariation = await variationRepository.create({
+          productSku: data.productSku,
+          selections: {}, // Empty for composite variations
+          weightOverride: undefined,
+        });
 
-      // Reload variations to get updated list
-      await loadVariations();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create variation');
-      throw err;
-    }
-  }, [variationRepository, loadVariations]);
+        // Reload variations to get updated list
+        await loadVariations();
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to create variation"
+        );
+        throw err;
+      }
+    },
+    [variationRepository, loadVariations]
+  );
 
   // Update variation
-  const updateVariation = useCallback(async (id: string, data: UpdateCompositeVariationData) => {
-    try {
-      setError(null);
+  const updateVariation = useCallback(
+    async (id: string, data: UpdateCompositeVariationData) => {
+      try {
+        setError(null);
 
-      // For now, we only support name updates through the underlying variation
-      // In a full implementation, we'd have a proper CompositeVariation repository
-      
-      // Update local state optimistically
-      setVariations(prev => prev.map(v => 
-        v.id === id ? { ...v, ...data, updatedAt: new Date() } : v
-      ));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update variation');
-      throw err;
-    }
-  }, []);
+        // For now, we only support name updates through the underlying variation
+        // In a full implementation, we'd have a proper CompositeVariation repository
+
+        // Update local state optimistically
+        setVariations((prev) =>
+          prev.map((v) =>
+            v.id === id ? { ...v, ...data, updatedAt: new Date() } : v
+          )
+        );
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to update variation"
+        );
+        throw err;
+      }
+    },
+    []
+  );
 
   // Delete variation
-  const deleteVariation = useCallback(async (id: string) => {
-    try {
-      setError(null);
+  const deleteVariation = useCallback(
+    async (id: string) => {
+      try {
+        setError(null);
 
-      // Delete composition items first
-      const variationSku = `${productSku}#${id}`;
-      const compositionItems = await compositionRepository.findByParent(variationSku);
-      
-      for (const item of compositionItems) {
-        await compositionRepository.delete(item.id);
+        // Delete composition items first
+        const variationSku = `${productSku}#${id}`;
+        const compositionItems =
+          await compositionRepository.findByParent(variationSku);
+
+        for (const item of compositionItems) {
+          await compositionRepository.delete(item.id);
+        }
+
+        // Delete the underlying product variation
+        await variationRepository.delete(id);
+
+        // Reload variations
+        await loadVariations();
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to delete variation"
+        );
+        throw err;
       }
-
-      // Delete the underlying product variation
-      await variationRepository.delete(id);
-
-      // Reload variations
-      await loadVariations();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete variation');
-      throw err;
-    }
-  }, [productSku, variationRepository, compositionRepository, loadVariations]);
+    },
+    [productSku, variationRepository, compositionRepository, loadVariations]
+  );
 
   // Add composition item to variation
-  const addCompositionItem = useCallback(async (variationId: string, itemData: CreateCompositionItemData) => {
-    try {
-      setError(null);
+  const addCompositionItem = useCallback(
+    async (variationId: string, itemData: CreateCompositionItemData) => {
+      try {
+        setError(null);
 
-      const variationSku = `${productSku}#${variationId}`;
-      await compositionRepository.create({
-        ...itemData,
-        parentSku: variationSku
-      });
+        const variationSku = `${productSku}#${variationId}`;
+        await compositionRepository.create({
+          ...itemData,
+          parentSku: variationSku,
+        });
 
-      // Reload variations to update composition
-      await loadVariations();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to add composition item');
-      throw err;
-    }
-  }, [productSku, compositionRepository, loadVariations]);
+        // Reload variations to update composition
+        await loadVariations();
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to add composition item"
+        );
+        throw err;
+      }
+    },
+    [productSku, compositionRepository, loadVariations]
+  );
 
   // Update composition item
-  const updateCompositionItem = useCallback(async (
-    variationId: string, 
-    itemId: string, 
-    itemData: UpdateCompositionItemData
-  ) => {
-    try {
-      setError(null);
+  const updateCompositionItem = useCallback(
+    async (
+      variationId: string,
+      itemId: string,
+      itemData: UpdateCompositionItemData
+    ) => {
+      try {
+        setError(null);
 
-      await compositionRepository.update(itemId, itemData);
+        await compositionRepository.update(itemId, itemData);
 
-      // Reload variations to update composition
-      await loadVariations();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update composition item');
-      throw err;
-    }
-  }, [compositionRepository, loadVariations]);
+        // Reload variations to update composition
+        await loadVariations();
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to update composition item"
+        );
+        throw err;
+      }
+    },
+    [compositionRepository, loadVariations]
+  );
 
   // Delete composition item
-  const deleteCompositionItem = useCallback(async (variationId: string, itemId: string) => {
-    try {
-      setError(null);
+  const deleteCompositionItem = useCallback(
+    async (variationId: string, itemId: string) => {
+      try {
+        setError(null);
 
-      await compositionRepository.delete(itemId);
+        await compositionRepository.delete(itemId);
 
-      // Reload variations to update composition
-      await loadVariations();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete composition item');
-      throw err;
-    }
-  }, [compositionRepository, loadVariations]);
+        // Reload variations to update composition
+        await loadVariations();
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to delete composition item"
+        );
+        throw err;
+      }
+    },
+    [compositionRepository, loadVariations]
+  );
 
   // Load variations on mount
   useEffect(() => {
@@ -186,6 +254,6 @@ export function useCompositeVariations(productSku: string) {
     addCompositionItem,
     updateCompositionItem,
     deleteCompositionItem,
-    reload: loadVariations
+    reload: loadVariations,
   };
 }

--- a/src/tests/features/use-composite-variations.test.ts
+++ b/src/tests/features/use-composite-variations.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useCompositeVariations } from "@/features/products/hooks/use-composite-variations";
+import { ProductVariationItemRepository } from "@/lib/storage/repositories/product-variation-item-repository";
+import { CompositionItemRepository } from "@/lib/storage/repositories/composition-item-repository";
+import { ProductRepository } from "@/lib/storage/repositories/product-repository";
+
+vi.mock("@/lib/storage/repositories/product-variation-item-repository");
+vi.mock("@/lib/storage/repositories/composition-item-repository");
+vi.mock("@/lib/storage/repositories/product-repository");
+vi.mock("@/lib/storage/storage-service");
+
+const mockVariationRepository = {
+  findByProductSku: vi.fn(),
+  create: vi.fn(),
+  delete: vi.fn(),
+};
+
+const mockCompositionRepository = {
+  findByParent: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+const mockProductRepository = {
+  findBySku: vi.fn(),
+};
+
+vi.mocked(ProductVariationItemRepository).mockImplementation(
+  () => mockVariationRepository as any
+);
+vi.mocked(CompositionItemRepository).mockImplementation(
+  () => mockCompositionRepository as any
+);
+vi.mocked(ProductRepository).mockImplementation(
+  () => mockProductRepository as any
+);
+
+describe("useCompositeVariations", () => {
+  const productSku = "PARENT-001";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calculates totalWeight using child product weights for simple products", async () => {
+    const variation = {
+      id: "var-1",
+      productSku,
+      selections: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockVariationRepository.findByProductSku.mockResolvedValue([variation]);
+
+    const compositionItems = [
+      {
+        id: "comp-1",
+        parentSku: `${productSku}#var-1`,
+        childSku: "CHILD-001",
+        quantity: 2,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "comp-2",
+        parentSku: `${productSku}#var-1`,
+        childSku: "CHILD-002",
+        quantity: 4,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    mockCompositionRepository.findByParent.mockResolvedValue(compositionItems);
+
+    mockProductRepository.findBySku.mockImplementation((sku: string) => {
+      const weight = sku === "CHILD-001" ? 1 : 0.5;
+      return Promise.resolve({
+        sku,
+        name: "Product",
+        weight,
+        isComposite: false,
+        hasVariation: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    });
+
+    const { result } = renderHook(() => useCompositeVariations(productSku));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.variations[0].totalWeight).toBeCloseTo(4);
+    expect(mockProductRepository.findBySku).toHaveBeenCalledWith("CHILD-001");
+    expect(mockProductRepository.findBySku).toHaveBeenCalledWith("CHILD-002");
+  });
+
+  it("calculates totalWeight using child product weights for variation SKUs", async () => {
+    const variation = {
+      id: "var-1",
+      productSku,
+      selections: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockVariationRepository.findByProductSku.mockResolvedValue([variation]);
+
+    const compositionItems = [
+      {
+        id: "comp-1",
+        parentSku: `${productSku}#var-1`,
+        childSku: "CHILD-003#opt",
+        quantity: 3,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    mockCompositionRepository.findByParent.mockResolvedValue(compositionItems);
+
+    mockProductRepository.findBySku.mockResolvedValue({
+      sku: "CHILD-003#opt",
+      name: "Child Variation",
+      weight: 5,
+      isComposite: false,
+      hasVariation: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const { result } = renderHook(() => useCompositeVariations(productSku));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.variations[0].totalWeight).toBe(15);
+    expect(mockProductRepository.findBySku).toHaveBeenCalledWith(
+      "CHILD-003#opt"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- fetch child product weights via `ProductRepository` when loading composite variations
- sum `childWeight * quantity` to compute each variation's total weight
- add hook tests for simple and variation child products

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68af8c1980b483308bd15e1ce447bcd5